### PR TITLE
Source .env file to read in sensitive environment variables

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -125,3 +125,6 @@ export GIT_EDITOR=vim
 ## Terminal
 alias profile_refresh="source ~/.zshrc && echo \"~/.zshrc profile refreshed\""
 alias ls='ls --color=auto'
+
+# Use Environment variables
+source ~/.env


### PR DESCRIPTION
Create an `~/.env` file to export API tokens so that the zshrc profile file can be versioned without sensitive data.